### PR TITLE
fix: remove superfluous generator arguments

### DIFF
--- a/index-2x.js
+++ b/index-2x.js
@@ -160,7 +160,7 @@ async function findAppModules() {
   // find all identifiers and, for enums, their array of values
   for (const mod of modules) {
     const modInfo = modulesInfo[mod.key.value];
-    const rename = makeRenameFunc(mod.key.value);
+    const rename = makeRenameFunc();
 
     // all identifiers will be initialized to "void 0" (i.e. "undefined") at the start, so capture them here
     walk.ancestor(mod, {
@@ -234,7 +234,7 @@ async function findAppModules() {
   // find the contents for all protobuf messages
   for (const mod of modules) {
     const modInfo = modulesInfo[mod.key.value];
-    const rename = makeRenameFunc(mod.key.value);
+    const rename = makeRenameFunc();
 
     // message specifications are stored in a "internalSpec" attribute of the respective identifier alias
     walk.simple(mod, {

--- a/index.js
+++ b/index.js
@@ -318,7 +318,7 @@ async function main() {
   // find all identifiers and, for enums, their array of values
   for (const mod of modules) {
     const modInfo = modulesInfo[mod.expression.arguments[0].value];
-    const rename = makeRenameFunc(mod.expression.arguments[0].value);
+    const rename = makeRenameFunc();
 
     const assignments = []
     walk.simple(mod, {
@@ -417,7 +417,7 @@ async function main() {
   // find the contents for all protobuf messages
   for (const mod of modules) {
     const modInfo = modulesInfo[mod.expression.arguments[0].value];
-    const rename = makeRenameFunc(mod.expression.arguments[0].value);
+    const rename = makeRenameFunc();
     const findByAliasInIdentifier = (obj, alias) => {
       return Object.values(obj).find(item => item.alias === alias);
     };


### PR DESCRIPTION
## Summary
- remove four unused arguments passed to makeRenameFunc
- cover both current and 2x bundle generators

## Validation
- node syntax checks for both generators
- npm test (4 passed)
- npm audit: 0 vulnerabilities